### PR TITLE
Adds Cosmos support to Orbis SDK

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 import { CeramicClient } from '@ceramicnetwork/http-client';
 import { TileDocument } from '@ceramicnetwork/stream-tile';
 import { DIDSession } from 'did-session'
-import { SolanaAuthProvider } from '@ceramicnetwork/blockchain-utils-linking'
+import { SolanaAuthProvider, CosmosAuthProvider } from '@ceramicnetwork/blockchain-utils-linking'
 import { EthereumWebAuth, getAccountId } from '@didtools/pkh-ethereum'
 
 /** To generate dids from a Seed */
@@ -354,6 +354,16 @@ export class Orbis {
 				error: e,
 				result: "Error generating Lit signature."
 			}
+		}
+	}
+
+
+	async testConnectCosmos() {
+		let provider;
+		if ('keplr' in window) {
+			provider = window.keplr?.cosmoshub;
+		} else {
+			console.log("You're out of space, I'm out of time");
 		}
 	}
 

--- a/utils/EthereumAuthProviderDefault.ts
+++ b/utils/EthereumAuthProviderDefault.ts
@@ -1,4 +1,4 @@
-import { EthereumAuthProvider, SolanaAuthProvider } from '@ceramicnetwork/blockchain-utils-linking'
+import { EthereumAuthProvider, SolanaAuthProvider, CosmosAuthProvider } from '@ceramicnetwork/blockchain-utils-linking'
 
 
 /** Replacing default EthereumAuthProvider class to force connection to an existing did if any. */


### PR DESCRIPTION
Serendipitously, `CosmosAuthProvider` is already present as a 3ID DID in Ceramic, so this begins the work of adding Cosmos to Orbis SDK, alongside Solana.